### PR TITLE
fix(a11y): improve WCAG contrast and readability in pricing section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7927,7 +7927,7 @@
 
 .foundation-value {
 	font-size: 14px;
-	color: var(--color-six);
+	color: var(--color-three);
 }
 
 .foundation-value span {
@@ -7995,6 +7995,41 @@
 
 .foundation-benefits-mobile .foundation-benefit-card span {
 	font-size: 11px;
+}
+
+/* Price Card Info Box (Dla kogo, Co się zmienia, etc.) */
+.price-info-box {
+	margin: 15px 0;
+	padding: 18px;
+	background: rgba(var(--white-color-rgb), 0.07);
+	border-radius: 8px;
+	font-size: 0.95em;
+	line-height: 1.7;
+	color: rgba(255, 255, 255, 0.92);
+}
+
+.price-info-box p {
+	margin: 0 0 12px 0;
+}
+
+.price-info-box p:last-child {
+	margin-bottom: 0;
+}
+
+.price-info-box strong {
+	color: var(--white-color);
+	display: inline-block;
+	margin-bottom: 2px;
+}
+
+/* Price Card Testimonial Quote */
+.price-testimonial {
+	margin-top: 15px;
+	padding: 12px;
+	font-style: italic;
+	font-size: 0.88em;
+	color: rgba(255, 255, 255, 0.78);
+	border-left: 2px solid var(--main-color);
 }
 
 /* Price Card Selectable */

--- a/sections/pricing.html
+++ b/sections/pricing.html
@@ -16,7 +16,7 @@
 				<!-- Decision Helper -->
 				<div class="sec-title style-two" style="margin-top: 40px; margin-bottom: 40px;">
 					<h3 style="color: #fff; font-size: 1.4em; margin-bottom: 20px;">Nie wiesz, od czego zacząć?</h3>
-					<div style="max-width: 650px; margin: 0 auto; text-align: left; color: rgba(255,255,255,0.85); font-size: 1.05em; line-height: 2;">
+					<div style="max-width: 650px; margin: 0 auto; text-align: left; color: rgba(255,255,255,0.92); font-size: 1.05em; line-height: 2;">
 						<strong style="color: #fff;">Co najbardziej przeszkadza Ci dzisiaj?</strong><br>
 						Chaos w głowie i brak czasu → <a href="#course-hp" style="color: var(--main-color);">Produktywność (1 497 PLN)</a><br>
 						Stres, presja, poczucie że zaraz się złamiesz → <a href="#course-sg" style="color: var(--main-color);">Silna Głowa (897 PLN)</a><br>
@@ -122,13 +122,13 @@
 											<div class="price-block_one-content">
 												<div class="d-flex justify-content-between align-items-end flex-wrap">
 													<div class="price-block_one-price">1 497<sup>PLN</sup><sub>&nbsp;</sub></div>
-													<div class="price-block_one-text">Flagowy kurs<br><span style="color:rgba(163, 163, 163, 0.5)">Najniższa cena z ostatnich 30 dni: 1 497 PLN</span></div>
+													<div class="price-block_one-text">Flagowy kurs<br><span style="color: var(--color-six);">Najniższa cena z ostatnich 30 dni: 1 497 PLN</span></div>
 												</div>
 
-												<div style="margin: 15px 0; padding: 15px; background: rgba(255,255,255,0.05); border-radius: 8px; font-size: 0.92em; line-height: 1.6;">
-													<strong>Dla kogo:</strong> Dla tych, którzy testowali każdy system, kalendarz i aplikację — a ich lista zadań i tak wygląda jak pole bitwy z samym sobą.<br><br>
-													<strong>Co się zmienia:</strong> Zamiast zarządzać zadaniami — zarządzasz energią. Zamiast walczyć z prokrastynacją — rozumiesz, skąd się bierze. Jedyna aplikacja mentalna, po której <em>nigdy więcej</em> nie potrzebujesz kolejnego kursu produktywności.<br><br>
-													<strong>6 modułów:</strong> Focus → Priorytety → Organizacja → Nawyki → Narzędzia → Wyższy Poziom
+												<div class="price-info-box">
+													<p><strong>Dla kogo:</strong> Dla tych, którzy testowali każdy system, kalendarz i aplikację — a ich lista zadań i tak wygląda jak pole bitwy z samym sobą.</p>
+													<p><strong>Co się zmienia:</strong> Zamiast zarządzać zadaniami — zarządzasz energią. Zamiast walczyć z prokrastynacją — rozumiesz, skąd się bierze. Jedyna aplikacja mentalna, po której <em>nigdy więcej</em> nie potrzebujesz kolejnego kursu produktywności.</p>
+													<p><strong>6 modułów:</strong> Focus → Priorytety → Organizacja → Nawyki → Narzędzia → Wyższy Poziom</p>
 												</div>
 
 												<ul class="price-block_one-list">
@@ -149,7 +149,7 @@
 													</a>
 												</div>
 
-												<div style="margin-top: 15px; padding: 12px; font-style: italic; font-size: 0.88em; color: rgba(255,255,255,0.6); border-left: 2px solid var(--main-color);">
+												<div class="price-testimonial">
 													"dzień 14 i po raz pierwszy od lat skończyłem robotę o 16 i nie czułem że powinienem jeszcze coś robić" — uczestnik, #wins na Discordzie
 												</div>
 
@@ -207,12 +207,12 @@
 											<div class="price-block_one-content">
 												<div class="d-flex justify-content-between align-items-end flex-wrap">
 													<div class="price-block_one-price">897<sup>PLN</sup><sub>&nbsp;</sub></div>
-													<div class="price-block_one-text">*TRWA PRZEDSPRZEDAŻ*<br><span style="color:rgba(163, 163, 163, 0.9)">Najniższa cena z ostatnich 30 dni: 897 PLN</span></div>
+													<div class="price-block_one-text">*TRWA PRZEDSPRZEDAŻ*<br><span style="color: var(--color-six);">Najniższa cena z ostatnich 30 dni: 897 PLN</span></div>
 												</div>
 
-												<div style="margin: 15px 0; padding: 15px; background: rgba(255,255,255,0.05); border-radius: 8px; font-size: 0.92em; line-height: 1.6;">
-													<strong>Dla kogo:</strong> Dla tych, którzy wiedzą, że ich głowa jest ich największym sojusznikiem — i jednocześnie ich największym przeciwnikiem.<br><br>
-													<strong>Co się zmienia:</strong> Presja przestaje paraliżować — zaczyna skupiać. Krytyka przestaje ranić — zaczyna informować. Firewall dla Twojego umysłu — nie kolejny artykuł o oddychaniu.
+												<div class="price-info-box">
+													<p><strong>Dla kogo:</strong> Dla tych, którzy wiedzą, że ich głowa jest ich największym sojusznikiem — i jednocześnie ich największym przeciwnikiem.</p>
+													<p><strong>Co się zmienia:</strong> Presja przestaje paraliżować — zaczyna skupiać. Krytyka przestaje ranić — zaczyna informować. Firewall dla Twojego umysłu — nie kolejny artykuł o oddychaniu.</p>
 												</div>
 
 												<ul class="price-block_one-list">
@@ -233,7 +233,7 @@
 													</a>
 												</div>
 
-												<div style="margin-top: 15px; padding: 12px; font-style: italic; font-size: 0.88em; color: rgba(255,255,255,0.6); border-left: 2px solid var(--main-color);">
+												<div class="price-testimonial">
 													"Koleżanka powiedziała mi coś, co normalnie zrujnowałoby mi tydzień. Tym razem usłyszałem — i poszedłem dalej. Bez dramatu." — uczestnik przedsprzedaży
 												</div>
 
@@ -291,12 +291,12 @@
 											<div class="price-block_one-content">
 												<div class="d-flex justify-content-between align-items-end flex-wrap">
 													<div class="price-block_one-price">777<sup>PLN</sup><sub>&nbsp;</sub></div>
-													<div class="price-block_one-text">*TRWA PRZEDSPRZEDAŻ*<br><span style="color:rgba(163, 163, 163, 0.9)">Najniższa cena z ostatnich 30 dni: 777 PLN</span></div>
+													<div class="price-block_one-text">*TRWA PRZEDSPRZEDAŻ*<br><span style="color: var(--color-six);">Najniższa cena z ostatnich 30 dni: 777 PLN</span></div>
 												</div>
 
-												<div style="margin: 15px 0; padding: 15px; background: rgba(255,255,255,0.05); border-radius: 8px; font-size: 0.92em; line-height: 1.6;">
-													<strong>Dla kogo:</strong> Dla tych, którzy odkryli, że autopilot prowadzi donikąd — i chcą przejąć stery.<br><br>
-													<strong>Co się zmienia:</strong> Medytacja dla ludzi z ADHD i analitycznym umysłem. Nie walczysz z myślami — przejmujesz kontrolę nad kokpitem. Życie przestaje Ci się "przydarzać" — zaczynasz je świadomie nawigować.
+												<div class="price-info-box">
+													<p><strong>Dla kogo:</strong> Dla tych, którzy odkryli, że autopilot prowadzi donikąd — i chcą przejąć stery.</p>
+													<p><strong>Co się zmienia:</strong> Medytacja dla ludzi z ADHD i analitycznym umysłem. Nie walczysz z myślami — przejmujesz kontrolę nad kokpitem. Życie przestaje Ci się "przydarzać" — zaczynasz je świadomie nawigować.</p>
 												</div>
 
 												<ul class="price-block_one-list">
@@ -316,7 +316,7 @@
 													</a>
 												</div>
 
-												<div style="margin-top: 15px; padding: 12px; font-style: italic; font-size: 0.88em; color: rgba(255,255,255,0.6); border-left: 2px solid var(--main-color);">
+												<div class="price-testimonial">
 													"Wczoraj stałem w korku 40 minut. Normalnie wściekłość. Tym razem — cisza. Świadoma, wybrana cisza. To jest inny poziom." — uczestnik
 												</div>
 
@@ -381,9 +381,9 @@
 													<div class="price-block_one-price" style="font-size: 1.2em;">Lista oczekujących</div>
 												</div>
 
-												<div style="margin: 15px 0; padding: 15px; background: rgba(255,255,255,0.05); border-radius: 8px; font-size: 0.92em; line-height: 1.6;">
-													<strong>Dla kogo:</strong> Dla mężczyzn, którzy czują, że grali według cudzych reguł w grę, której nie chcieli wygrywać.<br><br>
-													<strong>Co się zmienia:</strong> Reinstalacja systemu tożsamości. Siła przestaje być maską — staje się przezroczystą obecnością. Wrażliwość przestaje być słabością — staje się supermocą.
+												<div class="price-info-box">
+													<p><strong>Dla kogo:</strong> Dla mężczyzn, którzy czują, że grali według cudzych reguł w grę, której nie chcieli wygrywać.</p>
+													<p><strong>Co się zmienia:</strong> Reinstalacja systemu tożsamości. Siła przestaje być maską — staje się przezroczystą obecnością. Wrażliwość przestaje być słabością — staje się supermocą.</p>
 												</div>
 
 												<ul class="price-block_one-list">
@@ -403,7 +403,7 @@
 													</a>
 												</div>
 
-												<div style="margin-top: 15px; padding: 12px; font-style: italic; font-size: 0.88em; color: rgba(255,255,255,0.6); border-left: 2px solid var(--main-color);">
+												<div class="price-testimonial">
 													"Zdjąłem maskę 'zawsze silnego'. I okazało się, że pod spodem jest ktoś silniejszy." — uczestnik beta-testu
 												</div>
 
@@ -461,12 +461,12 @@
 											<div class="price-block_one-content">
 												<div class="d-flex justify-content-between align-items-end flex-wrap">
 													<div class="price-block_one-price">16 000<sup>PLN</sup><sub>&nbsp;</sub></div>
-													<div class="price-block_one-text">Tylko po wypełnieniu aplikacji<br><span style="color:rgba(163, 163, 163, 0.5)">Najniższa cena z ostatnich 30 dni: 16 000 PLN</span></div>
+													<div class="price-block_one-text">Tylko po wypełnieniu aplikacji<br><span style="color: var(--color-six);">Najniższa cena z ostatnich 30 dni: 16 000 PLN</span></div>
 												</div>
 
-												<div style="margin: 15px 0; padding: 15px; background: rgba(255,255,255,0.05); border-radius: 8px; font-size: 0.92em; line-height: 1.6;">
-													<strong>Dla kogo:</strong> Dla tych, którzy czują, że żadna pojedyncza "aplikacja" nie trafia w sedno — bo problem leży głębiej, na poziomie tego, kim jesteś, a nie tego, co robisz.<br><br>
-													<strong>Co dostajesz:</strong> 8 tygodni intensywnej pracy 1:1 z Ludwikiem. Diagnostyka, dekonstrukcja, integracja i nowy standard działania. Maksymalnie 5 osób jednocześnie.
+												<div class="price-info-box">
+													<p><strong>Dla kogo:</strong> Dla tych, którzy czują, że żadna pojedyncza "aplikacja" nie trafia w sedno — bo problem leży głębiej, na poziomie tego, kim jesteś, a nie tego, co robisz.</p>
+													<p><strong>Co dostajesz:</strong> 8 tygodni intensywnej pracy 1:1 z Ludwikiem. Diagnostyka, dekonstrukcja, integracja i nowy standard działania. Maksymalnie 5 osób jednocześnie.</p>
 												</div>
 
 												<ul class="price-block_one-list">
@@ -486,10 +486,10 @@
 															<span class="text-two">Umów Sesję Discovery</span>
 														</span>
 													</a>
-													<div style="margin-top: 8px; font-size: 0.85em; color: rgba(255,255,255,0.5);">30 minut · Bez zobowiązań · Żebyśmy obaj wiedzieli</div>
+													<div style="margin-top: 8px; font-size: 0.85em; color: rgba(255,255,255,0.75);">30 minut · Bez zobowiązań · Żebyśmy obaj wiedzieli</div>
 												</div>
 
-												<div style="margin-top: 15px; padding: 12px; font-style: italic; font-size: 0.88em; color: rgba(255,255,255,0.6); border-left: 2px solid var(--main-color);">
+												<div class="price-testimonial">
 													"Zapytał: 'Ile podatku płacisz każdego dnia za tę historię?' W 8 tygodni przeszłam od narracji ofiary do prawdziwej wiary w możliwości, które mam." — Anna, CEO Agencji Marketingowej
 												</div>
 
@@ -542,7 +542,7 @@
 					</div>
 					<div class="right-box" style="max-width: 500px;">
 						<h3 style="color: rgb(255, 255, 255);"><strong>Nie płacisz za dostęp do <span>Lifehackerów</span> — płacisz za program, który Cię tu wprowadza. A społeczność? To bonus. Dożywotni. <span style="text-decoration: underline;">Bez opłat</span>.</strong><br></h3>
-						<p style="color: grey; padding-top: 2em;">
+						<p style="color: var(--color-six); padding-top: 2em;">
 							Wiem, co myślisz. "Prawie 1 500 zł za kurs? Albo 16 000 za mentoring?"<br><br>
 							Masz rację — to nie jest impulsowy zakup. I dobrze. Bo to nie jest impulsowa decyzja.<br><br>
 							Ale żeby rzetelnie ocenić tę cenę, nie porównuj jej z ceną innego kursu. Porównaj ją z kosztem tego, jak żyjesz teraz. Ile godzin tygodniowo tracisz na rzeczy, które nie zbliżają Cię do tego, kim chcesz być? Pomnóż to przez swoją stawkę. Pomnóż to przez rok. Ta liczba jest prawie zawsze większa niż cena programu.<br><br>


### PR DESCRIPTION
- Replace low-contrast inline colors (rgba 0.5 opacity) with CSS variables
- Extract .price-info-box and .price-testimonial CSS classes from inline styles
- Replace <br><br> separators with semantic <p> tags in info boxes
- Bump foundation-value color from --color-six to --color-three
- Fix "Dlaczego takie ceny" paragraph color from grey to --color-six